### PR TITLE
Global Variable

### DIFF
--- a/extensions/input-output/include/flint_vm_output.h
+++ b/extensions/input-output/include/flint_vm_output.h
@@ -6,4 +6,8 @@ extern int FLINT_VM_print(Machine* machine);
 
 extern int FLINT_VM_println(Machine* machine);
 
+extern int FLINT_VM_put_int(Machine* machine);
+
+extern int FLINT_VM_put_int_line(Machine* machine);
+
 #endif /* FLINT_VM_OUTPUT_H */

--- a/extensions/input-output/src/flint_vm_output.c
+++ b/extensions/input-output/src/flint_vm_output.c
@@ -29,3 +29,21 @@ extern int FLINT_VM_println(Machine *machine) {
     return (-1);
   }
 }
+
+extern int FLINT_VM_put_int(Machine* machine) {
+  i32 value;
+
+  value = GET_I32_ARG(machine, 0);
+  printf("%d", value);
+
+  return 0;
+}
+
+extern int FLINT_VM_put_int_line(Machine* machine) {
+  i32 value;
+
+  value = GET_I32_ARG(machine, 0);
+  printf("%d\n", value);
+
+  return 0;
+}

--- a/src/byte_code_loader.c
+++ b/src/byte_code_loader.c
@@ -334,7 +334,7 @@ void load_function(Program *program, ByteCodeLoader *loader,
       break;
     }
     case CONSTANT_KIND_GLOBAL_VARIABLE: {
-      function->constant_pool[i].kind = CONSTANT_KIND_FUNCTION;
+      function->constant_pool[i].kind = CONSTANT_KIND_GLOBAL_VARIABLE;
       function->constant_pool[i].u.global_variable_v =
           &(program->global_variables[read_i32(loader)]);
       break;
@@ -376,6 +376,7 @@ void load_global_variable(Program *program, ByteCodeLoader *loader,
 
   if (initializer_offset >= 0 && initializer_offset < program->function_count) {
     global_variable->initializer = &(program->functions[initializer_offset]);
+    global_variable->is_initialized = FALSE;
   } else {
     add_loading_error(loader, "initializer offset not in the range");
 
@@ -449,7 +450,8 @@ void load_native_function(Program *program, ByteCodeLoader *loader,
   if (native_function->function_pointer) {
     free(func_name);
   } else {
-    add_loading_error(loader, "the function from the dynamic library cannot be loaded.");
+    add_loading_error(
+        loader, "the function from the dynamic library cannot be loaded.");
     free(func_name);
   }
 }

--- a/src/byte_code_printer.c
+++ b/src/byte_code_printer.c
@@ -67,7 +67,7 @@ void print_function_info(ByteCodePrinter *printer, Function *function) {
   function_name = str_to_c_str(function->name);
   printf("function: %s\n", function_name);
   free(function_name);
-  printf("stack= %d, ", function->stack);
+  printf("stack = %d, ", function->stack);
   printf("args_size = %d, ", function->args_size);
   printf("locals = %d\n", function->locals);
 

--- a/src/machine.c
+++ b/src/machine.c
@@ -97,7 +97,7 @@
   call_info = (CallInfo *)&(stack[sp]);                                        \
   call_info->caller = machine->env.function;                                   \
   call_info->caller_fp = fp;                                                   \
-  call_info->caller_pc = pc - 2;                                               \
+  call_info->caller_pc = pc;                                                   \
   sp = sp + CALL_INFO_ALIGN_SIZE;                                              \
   machine->env.function = callee;                                              \
   pc = callee->code;                                                           \

--- a/test/test_global_variable.c
+++ b/test/test_global_variable.c
@@ -7,12 +7,13 @@
 void test_global_variable() {
   Program *program;
   Machine *machine;
-  Byte global_variable_initialization_code[] = {PUSH_F64_1,
-                                                /* invoke function */
-                                                POP_GLOBAL_F64, 0,
-                                                /* return */
-                                                RETURN};
-  Byte entry_function_code[] = {PUSH_GLOBAL_F64, 0, PUSH_F64, 1, ADD_F64, PUSH_I32_0, HALT};
+  Byte global_variable_initialization_code[] = {
+      /* The value assigned to the global variable. */
+      PUSH_F64_1,
+      /* return */
+      RETURN_F64};
+  Byte entry_function_code[] = {PUSH_GLOBAL_F64, 0,          PUSH_F64, 1,
+                                ADD_F64,         PUSH_I32_0, HALT};
   Function *entry;
   Function *initializer;
 


### PR DESCRIPTION
1. Update the method of initializing the global variable. Initially, it assumes that the initialization function is a procedure, which assigns a value to the global variable via POP_GLOBAL_TYPE. Now, it assumes that the initialization function is a function that returns a value to the global variable.
2. Fix some issues.
3. Add two implementations of native functions.